### PR TITLE
% formatting will not be removed from the language

### DIFF
--- a/source/improving.rst
+++ b/source/improving.rst
@@ -127,9 +127,6 @@ go overboard you lose the benefit of the more readable syntax:
 For a full specification of the advanced string formatting syntax see
 the ``Common String Operations`` section of the Python documentation\ [#asf]_.
 
-The old string formatting based on % is planned to be eventually removed, but
-there is no decided timeline for this.
-
 ---------------------------------------------------------------------------
 Class decorators
 ---------------------------------------------------------------------------


### PR DESCRIPTION
Early in Python 3's history this claim was made in official sources, but there is no longer any plan to remove % style string formatting and to break existing code that uses it.