### PR TITLE
Suggestion on how to doctest functions that return (unicode) strings

### DIFF
--- a/source/_tests/doctest-checker.txt
+++ b/source/_tests/doctest-checker.txt
@@ -1,0 +1,14 @@
+import re, sys
+from doctest import OutputChecker, DocTestSuite
+
+class Py23DocChecker(OutputChecker):
+    def check_output(self, want, got, optionflags):
+        if sys.version_info[0] < 3:
+            # if running on py2, attempt to prefix all the strings
+            # with "u" to signify that they're unicode literals
+            want = re.sub("'(.*?)'", "u'\\1'", want)
+        return OutputChecker.check_output(self, want, got, optionflags)
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(DocTestSuite(mymodule, checker=Py23DocChecker()))
+    return tests

--- a/source/_tests/doctest-unicode-fail.txt
+++ b/source/_tests/doctest-unicode-fail.txt
@@ -1,0 +1,2 @@
+>>> readfile()
+'Hello'

--- a/source/_tests/doctest-unicode.txt
+++ b/source/_tests/doctest-unicode.txt
@@ -1,0 +1,2 @@
+>>> readfile() == 'Hello'
+True

--- a/source/problems.rst
+++ b/source/problems.rst
@@ -567,6 +567,42 @@ a helper function that makes sure the output is a string before printing it:
 It also removes leading and trailing whitespace for good measure, so that
 you don't have to have as many ``<BLANKLINE>`` statements in the code.
 
+Unicode representation
+======================
+
+Output from functions that return text data, like reading from a file
+with a declared encoding, will return ``unicode`` under Python 2,
+while in Python 3 they will return ``str``, which has a different
+native representation. A simple function like this, which returns text data, will fail on Python 2.
+
+.. literalinclude:: _tests/doctest-unicode-fail.txt
+
+The problem is that a ``unicode`` string will be written like
+``u'Hello'`` under Python 2, and the same function will returning a
+``str`` that will be written like ``'Hello'`` under Python 3. One
+woraround is to use ``from __future__ import unicode_literals`` and
+write doctests in a contorted style:
+
+.. literalinclude:: _tests/doctest-unicode.txt
+
+A more complex workaround, but which leads to doctests that are easier
+to read, is to write your tests to expect Python 3-style string
+literals, and then re-write them on the fly if you're testing under
+Python 2. This will require you to run doctests from within the
+unittest framework, using the ``load_tests`` mechanism and specifying
+a special checker class that transforms the expected output just prior
+to checking it:
+		    
+.. literalinclude:: _tests/doctest-checker.txt
+
+.. note::
+
+   This recipe is adapted from
+   http://dirkjan.ochtman.nl/writing/2014/07/06/single-source-python-23-doctests.html,
+   but rewritten to use the Python 3 formatting as the native one.
+
+
+		    
 ``dict`` and ``set`` order
 ==========================
 


### PR DESCRIPTION
I love the book, and have found it invaluable when writing code that works on both Py2 and 3. One problem I've had that wasn't directly addressed in the book was how to handle doctests of functions that return (unicode) strings. I found a solution elsewhere (https://dirkjan.ochtman.nl/writing/2014/07/06/single-source-python-23-doctests.html), repackaged it slightly to use Python 3 string literals by default, and wrote some text discussing the problem. Hope that it's useful!