### PR TITLE
Fix suggested `round` replacement for negatives.

### DIFF
--- a/source/_tests/round26.txt
+++ b/source/_tests/round26.txt
@@ -1,7 +1,10 @@
 >>> import math
 >>> def my_round(x, d=0):
 ...     p = 10 ** d
-...     return float(math.floor((x * p) + math.copysign(0.5, x)))/p
+...     if x > 0:
+...         return float(math.floor((x * p) + 0.5))/p
+...     else:
+...         return float(math.ceil((x * p) - 0.5))/p
 
 >>> my_round(1.5)
 2.0


### PR DESCRIPTION
The proposed function for mimicking Python 2 `round` behavior is incorrect for negative numbers. Example:

```
>>> my_round(0.1)
0.0  # good!

>>> my_round(-0.1)
-1.0  # bad!

>>> round(-0.1)
0  # expected
```

I believe the proposed function tried to support negatives (it used `math.copysign()` to add a negative 0.5), however the use of `math.floor()` is wrong here because it floors toward negative infinity rather than toward zero. The cleanest solution I can come up with is to simply use an if-else.

This feels worthy of adding to the errata, but I wasn't sure what section it should go in so I didn't attempt to add it.