### PR TITLE
fix minor typos

### DIFF
--- a/source/about.rst
+++ b/source/about.rst
@@ -8,7 +8,7 @@ About this book
 
 This book is an open book whose source is available on GitHub\ [#GitHub]_
 so that anyone can contribute to the book. The author and editor is
-Lennart Regebro, and future contibutors will be listed here.
+Lennart Regebro, and future contributors will be listed here.
 
 This book is written in reStructuredText\ [#rest]_, typeset with
 Sphinx\ [#sphinx]_ and LaTeX\ [#latex]_ and printed on

--- a/source/cextensions.rst
+++ b/source/cextensions.rst
@@ -208,7 +208,7 @@ for that.
 Another option is to define three functions. Firstly the actual module
 initialization function, returning a ``PyObject*`` and then two wrappers. One
 for Python 3 that calls the first and returns the value and one for Python 2
-that calls the module initizaliation without returning a value:
+that calls the module initialization without returning a value:
 
 .. code-block:: none
 

--- a/source/differences.rst
+++ b/source/differences.rst
@@ -7,7 +7,7 @@ This appendix contains a listing of the differences between Python 2 and Python
 conversion.
 
 This listing is incomplete. What is listed here is only the intentional changes
-that are not bug fixes and even so there may be accidental ommissions.
+that are not bug fixes and even so there may be accidental omissions.
 
 ---------------------------------------------------------------------------
 ``apply()``
@@ -279,7 +279,7 @@ to the Python 3 behavior.
 
 If you need to support Python 2.4 or earlier you have to spell out the whole
 package name so ``import csv`` becomes ``from mypkg import csv`` and ``from csv
-import my_csv`` becomes ``from mypckg.csv import my_csv``. For clarity and
+import my_csv`` becomes ``from mypkg.csv import my_csv``. For clarity and
 readability I would avoid relative imports if you can and always spell out
 the whole path.
 
@@ -401,15 +401,15 @@ iterables are exhausted, extending the other arguments with ``None``.
 .. literalinclude:: _tests/map25.txt
 
 In Python 3 ``map()`` will instead stop at the shortest of the arguments. If
-you want the Python 2 behaviour in Python 3 you can use a combination of
+you want the Python 2 behavior in Python 3 you can use a combination of
 ``starmap()`` and ``zip_longest()``.
 
 .. literalinclude:: _tests/map30.txt
 
 The Python 2 ``map()`` will accept ``None`` as it's function argument, where
 it will just return the object(s) passed in. As this transforms ``map()``
-into ``zip()`` it's not particularily useful, and in Python 3 this no longer
-works. However, some code dependes on this behavior, and you can use the
+into ``zip()`` it's not particularly useful, and in Python 3 this no longer
+works. However, some code depends on this behavior, and you can use the
 following function as a full replacement for the Python 2 map.
 
 .. literalinclude:: _tests/map2.py

--- a/source/improving.rst
+++ b/source/improving.rst
@@ -203,7 +203,7 @@ More comprehensions
 
 Generators have been around since Python 2.2, but a new way to make
 generators appeared in Python 2.4, namely generator expressions. These
-are like list comprehesions, but instead of returning a list, they return
+are like list comprehensions, but instead of returning a list, they return
 a generator. They can be used in many places where list comprehensions are
 normally used:
 
@@ -250,7 +250,7 @@ from the iterator.
 .. literalinclude:: _tests/test-7.10.txt
 
 This special method has in Python 3 been renamed to ``.__next__()`` to be
-consistent with the naming of special attributes elswhere in Python. However,
+consistent with the naming of special attributes elsewhere in Python. However,
 you should generally not call it directly, but instead use the builtin
 ``next()`` function. This function is also available from Python 2.6, so
 unless you are supporting Python 2.5 or earlier you can switch.

--- a/source/intro.rst
+++ b/source/intro.rst
@@ -24,7 +24,7 @@ Python on the way.
 Most surprising was how little the fundamentals have changed. Writing code with
 Python 3 still feels just like the old comfortable shoes, but newly shined and
 with new laces. The hardest change to get used to is to remember that ``print``
-is a function. The relatively small differences doesn't necessarily mean that
+is a function. The relatively small differences don't necessarily mean that
 supporting Python 3 is easy, but it can be and hopefully this book will make it
 even easier.
 

--- a/source/noconv.rst
+++ b/source/noconv.rst
@@ -258,7 +258,7 @@ Two times three is "six"
 
 There are many many more unusual and sometimes subtle differences between
 Python 2 and Python 3. Although the techniques mentioned here works for most
-of them, I definitely recommend you to look at Benjamin Petersons module
+of them, I definitely recommend you to look at Benjamin Peterson's module
 "six"\ [#six]_ It contains a ``PY3`` constant to use when checking for the version of
 Python, and it contains the above mentioned ``b()`` and ``u()`` functions,
 although the ``u()`` function doesn't specify an encoding, so you are restricted

--- a/source/problems.rst
+++ b/source/problems.rst
@@ -355,7 +355,7 @@ different on different platforms. If it has any other encoding you need to pass
 that encoding into the ``open()`` function as a parameter. In Python 2 the
 ``open()`` function doesn't take an encoding parameter and will return a ``str``
 object. As long as your file contains only ASCII characters this isn't a
-problem, but when it does you will have to make some changes.
+problem, but when it doesn't you will have to make some changes.
 
 Opening the file as binary and decoding the data afterward is an option, for
 example with ``codecs.open()``. However, the translation of line endings that
@@ -578,9 +578,9 @@ native representation. A simple function like this, which returns text data, wil
 .. literalinclude:: _tests/doctest-unicode-fail.txt
 
 The problem is that a ``unicode`` string will be written like
-``u'Hello'`` under Python 2, and the same function will returning a
+``u'Hello'`` under Python 2, and the same function will return a
 ``str`` that will be written like ``'Hello'`` under Python 3. One
-woraround is to use ``from __future__ import unicode_literals`` and
+workaround is to use ``from __future__ import unicode_literals`` and
 write doctests in a contorted style:
 
 .. literalinclude:: _tests/doctest-unicode.txt

--- a/source/stdlib.rst
+++ b/source/stdlib.rst
@@ -17,7 +17,7 @@ consistent and easier to use. All the module names now conform to the
 style guide for Python code, PEP 8\ [#pep8]_,
 and several modules have been merged.
 
-``2to3`` contains fixers for all of this, so this sectin is mostly of interest
+``2to3`` contains fixers for all of this, so this section is mostly of interest
 if you need to support both Python 2 and Python 3 without ``2to3`` conversion.
 
 The ``six`` module\ [#six]_ has support for most of the standard library

--- a/source/strategies.rst
+++ b/source/strategies.rst
@@ -132,7 +132,7 @@ one of the major difficulties in supporting Python 3.
 
 .. index:: six
 
-Benjamin Petersons excellent ``six`` module\ [#six]_ also helps by wrapping
+Benjamin Peterson's excellent ``six`` module\ [#six]_ also helps by wrapping
 much of the incompatibilities, and since the need to support older Python
 versions is shrinking, supporting both Python 2 and Python 3 without conversion
 is becoming the preferred method.


### PR DESCRIPTION
Thanks for all the work on this book!

This changeset fixes a number of minor typos. Note, the single British spelling of "behaviour" was changed to match the rest of the book, which uses the American "behavior".