### PR TITLE
Updated out-of-date links to Sphinx

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -77,7 +77,7 @@
       {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
     {%- endif %}
     {%- if show_sphinx %}
-      {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
+      {% trans sphinx_version=sphinx_version|e %}Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
     {%- endif %}
         </div>
         <div class="clearer"></div>

--- a/source/_templates/sphinxcustom.cls
+++ b/source/_templates/sphinxcustom.cls
@@ -1,5 +1,5 @@
 %
-% sphinxmanual.cls for Sphinx (http://sphinx.pocoo.org/)
+% sphinxmanual.cls for Sphinx (https://www.sphinx-doc.org/)
 %
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]

--- a/source/about.rst
+++ b/source/about.rst
@@ -65,7 +65,7 @@ I have tried to avoid using the word "porting" in the text as a part of this.
 .. rubric:: Footnotes
 
 .. [#rest] `http://docutils.sourceforge.net/rst.html <http://docutils.sourceforge.net/rst.html>`_
-.. [#sphinx] `http://sphinx.pocoo.org/ <http://sphinx.pocoo.org/>`_
+.. [#sphinx] `https://www.sphinx-doc.org/ <https://www.sphinx-doc.org/>`_
 .. [#latex] `http://www.latex-project.org/ <http://www.latex-project.org/>`_
 .. [#createspace] `https://www.createspace.com/ <https://www.createspace.com/>`_
 .. [#GitHub] `https://github.com/regebro/supporting-python-3 <https://github.com/regebro/supporting-python-3>`_


### PR DESCRIPTION
Hello, just a tiny fix. The links to Sphinx (<http://sphinx.pocoo.org/>0 were out-of-date and returning "400 Bad Request". I've updated the URLs to the current home page <https://www.sphinx-doc.org>. Hope this helps.